### PR TITLE
Fix my emacs config to support gcc too

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -9,6 +9,7 @@
                                          (format "-I%s"
                                                  src-path))))
                    (setq-local flycheck-clang-include-path include-path)
+                   (setq-local flycheck-gcc-include-path include-path)
                    (setq-local company-clang-arguments clang-argument)
                    (setq-local company-c-headers-path-user
                                (append company-c-headers-path-user


### PR DESCRIPTION
My linters was complaining about not finding the Vector2D.hpp header,
that occurs because I did not clang instaled, only gcc.

This change fixed.