### PR TITLE
Reinforce good C++ practices

### DIFF
--- a/examples/lerax-square.cpp
+++ b/examples/lerax-square.cpp
@@ -3,7 +3,8 @@
 #include <string>
 
 #include <SDL2/SDL.h>
-#include <Vector2D.hpp>
+
+#include "Vector2D.hpp"
 
 #define SCREEN_WIDTH 800
 #define SCREEN_HEIGHT 600


### PR DESCRIPTION
The NULL is not statically typed and does not provide the safety that C++ brings with C++11 when comparing pointers. Thus, the change was done to improve code in this aspect.

A change on the Makefile is on its way , do not merge this yet.

