### PR TITLE
Add fps_lock method to GameLoop and public attr fps_target

### DIFF
--- a/examples/lerax-breakout.cpp
+++ b/examples/lerax-breakout.cpp
@@ -154,6 +154,7 @@ class Game: public GameLoop {
 
     void start() {
         // initialize blocks
+        fps_target = 60;
         ball.velocity = {150, 300};
         for (int i = 0; i < BLOCKS; ++i) {
             for (int j = 0; j < SCREEN_WIDTH / BLOCK_SIZE / 2  ; j++) {

--- a/examples/lerax-breakout.cpp
+++ b/examples/lerax-breakout.cpp
@@ -154,7 +154,7 @@ class Game: public GameLoop {
 
     void start() {
         // initialize blocks
-        fps_target = 60;
+        set_max_frame_rate(60);
         ball.velocity = {150, 300};
         for (int i = 0; i < BLOCKS; ++i) {
             for (int j = 0; j < SCREEN_WIDTH / BLOCK_SIZE / 2  ; j++) {

--- a/examples/lerax-square-platform.cpp
+++ b/examples/lerax-square-platform.cpp
@@ -288,7 +288,7 @@ private:
         player.position.x = SCREEN_WIDTH / 2;
         player.position.y = SCREEN_HEIGHT - player.size;
         player.update_rect();
-
+        fps_target = 120;
         int block_size = 50;
         colliders.push_back(&collider_screen);
         SDL_Rect block1 = {.x=0,

--- a/examples/lerax-square-platform.cpp
+++ b/examples/lerax-square-platform.cpp
@@ -288,7 +288,7 @@ private:
         player.position.x = SCREEN_WIDTH / 2;
         player.position.y = SCREEN_HEIGHT - player.size;
         player.update_rect();
-        fps_target = 120;
+        set_max_frame_rate(120);
         int block_size = 50;
         colliders.push_back(&collider_screen);
         SDL_Rect block1 = {.x=0,

--- a/examples/lerax-square.cpp
+++ b/examples/lerax-square.cpp
@@ -133,7 +133,7 @@ private:
 
     void start() {
         cout << ":: Game initialization!" << endl;
-        fps_target = 60;
+        set_max_frame_rate(60);
         player.position.x = SCREEN_WIDTH / 2;
         player.position.y = SCREEN_HEIGHT / 2;
     }

--- a/examples/lerax-square.cpp
+++ b/examples/lerax-square.cpp
@@ -133,6 +133,7 @@ private:
 
     void start() {
         cout << ":: Game initialization!" << endl;
+        fps_target = 60;
         player.position.x = SCREEN_WIDTH / 2;
         player.position.y = SCREEN_HEIGHT / 2;
     }

--- a/examples/wesleycsj-doom-fire.cpp
+++ b/examples/wesleycsj-doom-fire.cpp
@@ -70,7 +70,7 @@ class Game: public GameLoop {
     };
     std::vector<int> tiles;
     void start(){
-        fps_target = 60;
+        set_max_frame_rate(60);
         for (int i = 0; i < widthQuantity; i++){
             for (int j = 0; j < heightQuantity; j++){
                 if (j == (heightQuantity - 1)){

--- a/examples/wesleycsj-doom-fire.cpp
+++ b/examples/wesleycsj-doom-fire.cpp
@@ -70,6 +70,7 @@ class Game: public GameLoop {
     };
     std::vector<int> tiles;
     void start(){
+        fps_target = 60;
         for (int i = 0; i < widthQuantity; i++){
             for (int j = 0; j < heightQuantity; j++){
                 if (j == (heightQuantity - 1)){

--- a/examples/wesleycsj-hello-world.cpp
+++ b/examples/wesleycsj-hello-world.cpp
@@ -1,5 +1,5 @@
 /*
- *	Author: WesleyCSJ
+ *  Author: WesleyCSJ
  *  Description: Render four colors on screen with 2s delay
  *
  *
@@ -16,51 +16,51 @@ std::map<const char*, SDL_Keycode> input_config = {
 };
 
 class Game: public GameLoop {
-	using GameLoop::GameLoop;
-	InputHandler input_handler = InputHandler(input_config);
-	float screenCounter = 0;
-	int colorCursor = 0;
-	int colors[4][4] = {
-		{225,  0,  0,0},
-		{247,227,  0, 97},
-		{25 ,235,  0, 42},
-		{0  ,1  ,224,255}
-	};
+    using GameLoop::GameLoop;
+    InputHandler input_handler = InputHandler(input_config);
+    float screenCounter = 0;
+    int colorCursor = 0;
+    int colors[4][4] = {
+        {225,  0,  0,0},
+        {247,227,  0, 97},
+        {25 ,235,  0, 42},
+        {0  ,1  ,224,255}
+    };
 
-	void event(){
-		static SDL_Event e;
-		input_handler.process(e);
-		//This is obligatory, if not, window will run forever and be blocked by OS when tried to close.
-		running = !(input_handler.read("quit") || input_handler.read(SDL_QUIT));
+    void event(){
+        static SDL_Event e;
+        input_handler.process(e);
+        //This is obligatory, if not, window will run forever and be blocked by OS when tried to close.
+        running = !(input_handler.read("quit") || input_handler.read(SDL_QUIT));
 
-	}
+    }
 
-	void update(float dt) {
-		screenCounter = screenCounter + dt;
-		int *color = colors[colorCursor];
+    void update(float dt) {
+        screenCounter = screenCounter + dt;
+        int *color = colors[colorCursor];
 
-		if (screenCounter > 2.0f){
-			screenCounter = 0;
-			if (colorCursor < 3){
-				colorCursor = colorCursor + 1;
-			} else {
-				colorCursor = 0;
-			}
-		}
+        if (screenCounter > 2.0f){
+            screenCounter = 0;
+            if (colorCursor < 3){
+                colorCursor = colorCursor + 1;
+            } else {
+                colorCursor = 0;
+            }
+        }
 
-	}
+    }
 
-	void render(){
-		//Sets a color in a renderer and render on screen
-		int *color = colors[colorCursor];
-		SDL_SetRenderDrawColor(renderer, color[0] , color[1], color[2], color[3]);
-		SDL_RenderClear(renderer);
-		SDL_RenderPresent(renderer);
-	}
+    void render(){
+        //Sets a color in a renderer and render on screen
+        int *color = colors[colorCursor];
+        SDL_SetRenderDrawColor(renderer, color[0] , color[1], color[2], color[3]);
+        SDL_RenderClear(renderer);
+        SDL_RenderPresent(renderer);
+    }
 };
 
 int main(int argc, char** argv){
-	Game game("Hello World", SCREEN_WIDTH, SCREEN_HEIGHT);
+    Game game("Hello World", SCREEN_WIDTH, SCREEN_HEIGHT);
     game.set_max_frame_rate(60);
-	return game.run();
+    return game.run();
 }

--- a/examples/wesleycsj-hello-world.cpp
+++ b/examples/wesleycsj-hello-world.cpp
@@ -61,5 +61,6 @@ class Game: public GameLoop {
 
 int main(int argc, char** argv){
 	Game game("Hello World", SCREEN_WIDTH, SCREEN_HEIGHT);
+    game.fps_target = 60;
 	return game.run();
 }

--- a/examples/wesleycsj-hello-world.cpp
+++ b/examples/wesleycsj-hello-world.cpp
@@ -46,7 +46,7 @@ class Game: public GameLoop {
 			} else {
 				colorCursor = 0;
 			}
-		} 
+		}
 
 	}
 
@@ -61,6 +61,6 @@ class Game: public GameLoop {
 
 int main(int argc, char** argv){
 	Game game("Hello World", SCREEN_WIDTH, SCREEN_HEIGHT);
-    game.fps_target = 60;
+    game.set_max_frame_rate(60);
 	return game.run();
 }

--- a/src/GameLoop.hpp
+++ b/src/GameLoop.hpp
@@ -22,7 +22,11 @@ protected:
     virtual void start() {};
     virtual void stop() {};
 public:
-    int fps_target = 0;
+    int fps_target = 240;
+
+    void set_max_frame_rate(int fps) {
+        this->fps_target = fps;
+    }
 
     GameLoop(const char* title, int width, int height) {
         if (SDL_Init(SDL_INIT_VIDEO) < 0) {


### PR DESCRIPTION
Closes #26 

Set fps_target for all examples

- lerax-breakout -> 60fps
- lerax-square -> 60fps
- lerax-square-platform -> 120fps (60fps is not enough)
- wesleycsj-doom-fire -> 60fps
- wesleycsj-hello-world -> 60fps

Now the CPU consumption is very low! My CPU temp is not burning
anymore.